### PR TITLE
正規表現のマッチの順番を考慮する

### DIFF
--- a/app/generate_masked_wc.py
+++ b/app/generate_masked_wc.py
@@ -32,7 +32,7 @@ def generate_masked_wc(words, bucket, birthday_character):
         mask=mask_array,
         color_func=image_color,
         stopwords=stopwords,
-        regexp="[\wΑ-ω]+|[\wΑ-ω]+[\wΑ-ω・’.]*[\wΑ-ω]+",
+        regexp="[\wΑ-ω]+[\wΑ-ω・’.]*[\wΑ-ω]+|[\wΑ-ω]+",
         background_color='white',
         include_numbers=False
     )

--- a/app/generate_wc.py
+++ b/app/generate_wc.py
@@ -36,7 +36,7 @@ def generate_wc(words, img_config, bucket):
         height=height,
         # mask=msk,
         stopwords=stopwords,
-        regexp="[\wΑ-ω]+|[\wΑ-ω]+[\wΑ-ω・’.]*[\wΑ-ω]+",
+        regexp="[\wΑ-ω]+[\wΑ-ω・’.]*[\wΑ-ω]+|[\wΑ-ω]+",
         background_color='white',
         colormap=colormap,
         include_numbers=False


### PR DESCRIPTION
* 基本的に，|で区切られた正規表現は、左から右に評価されるため，元のパターンだと"A・ZU・NA"が全体でマッチしないので"A・ZU・NA"全体がマッチするパターンを最も左に書く